### PR TITLE
less noise in the logs

### DIFF
--- a/ultrasonic/ultrasonic_sensor.go
+++ b/ultrasonic/ultrasonic_sensor.go
@@ -137,7 +137,7 @@ func (s *usSensor) Readings(ctx context.Context, extra map[string]interface{}) (
 	}
 
 	s.board.StreamTicks(ctx, []board.DigitalInterrupt{echoInterrupt}, s.ticksChan, nil)
-	fmt.Println("returning stream ticks")
+	s.logger.Debug("returning stream ticks")
 
 	// we send a high and a low to the trigger pin 10 microseconds
 	// apart to signal the sensor to begin sending the sonic pulse


### PR DESCRIPTION
I got tired of having 2 lines of logs every time I clicked the "Get Readings" button in the RC card. So, it's now a debug log instead of a print statement. (I question whether it needs to be there at all, but someone found it useful, so I kept it at debug-level.)

Tried on my rpi5: seems to work like normal.

I was unable to cross-compile for aarch64 from my x86 machine, despite running `TARGET_ARCH=aarch64 make`: that just put an x86 executable in `bin/aarch64`. So, I used `canon` to emulate an aarch64 machine, and then I could build for my rpi5. I wonder if there's something to change in the makefile to get that to work smoother, but I couldn't figure it out in 5 minutes and then decided it wasn't worth the effort right now.